### PR TITLE
Manifest v2 to v3 updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Unfortunately those printers [don't set any CORS headers](https://developer.zebr
 
 This extension circumvents this issue.
 
-[![Available in the Chrome Web Store](https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png)](https://chrome.google.com/webstore/detail/ndikjdigobmbieacjcgomahigeiobhbo)
+[![Available in the Chrome Web Store](https://storage.googleapis.com/web-dev-uploads/image/WlD8wC6g8khYWPJUsQceQkhXSlv1/UV4C4ybeBTsZt43U4xis.png)](https://chrome.google.com/webstore/detail/ndikjdigobmbieacjcgomahigeiobhbo)
 
 ## Usage
 
@@ -14,11 +14,13 @@ Install this extension from the [Chrome Web Store](https://chrome.google.com/web
 
 In your web app you can now directly print to Zebra printers by using [`window.postMessage()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage):
 
-    window.postMessage({
-        type: "zebra_print_label",
-        zpl: "^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ",
-        url: "http://192.168.37.36/pstprnt"
-    }, "*");
+```javascript
+window.postMessage({
+    type: "zebra_print_label",
+    zpl: "^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ",
+    url: "http://192.168.37.36/pstprnt"
+}, "*");
+```
 
 The Zebra Printing extension will listen to those messages and print the `zpl` to the `url`.
 
@@ -28,13 +30,15 @@ The Zebra Printing extension will listen to those messages and print the `zpl` t
 
 The extension will also post a message to the web page upon loading. This way in your web app you can check if the extension is installed:
 
-    window.addEventListener("message", function (event) {
-        if (!event.data.ZebraPrintingVersion) {
-            return;
-        }
-        // extension installed, enable print button or whatever...
-        console.log(event.data);
-    });
+```javascript
+window.addEventListener("message", function (event) {
+    if (!event.data.ZebraPrintingVersion) {
+        return;
+    }
+    // extension installed, enable print button or whatever...
+    console.log(event.data);
+});
+```
 
 The event will contain two fields:
 
@@ -45,6 +49,9 @@ The event will contain two fields:
 
 - ZT220 with firmware V72.19.15Z
 - ZT220 with firmware V72.20.01Z
+- ZD620 with firmware V84.20.10Z, V84.20.18Z, V84.20.21Z
+- ZD621 with firmware V93.21.07Z
+- GK420d with firmware V61.17.17Z
 
 Feel free to open a pull request to add other supported printers!
 
@@ -52,16 +59,20 @@ Feel free to open a pull request to add other supported printers!
 
 For local development/testing:
 
-    cd testing/
-    openssl req -new -x509 -keyout server.pem -out server.pem -days 365 -nodes
-    python simple-https-server.py
-    open https://localhost:4443/
+```shell
+cd testing/
+openssl req -new -x509 -keyout server.pem -out server.pem -days 365 -nodes
+python simple-https-server.py
+open https://localhost:4443/
+```
 
 ## Release
 
 Just zip up the `extension` directory:
 
-    zip -FSr extension.zip extension
+```shell
+zip -FSr extension.zip extension
+```
 
 ## Known Limitations
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -3,20 +3,29 @@ console.log('background.js loaded');
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     console.log(message);
 
-    var request = new XMLHttpRequest();
-
-    request.onload = function () {
-        sendResponse({ status: request.status });
-    }
-
-    request.open('POST', message.url, true);
-    request.send(message.zpl);
+    fetch(message.url, {
+        method: 'POST',
+        body: message.zpl
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        return response.status
+    })
+    .then(data => {
+        sendResponse({ status: 200 });
+    })
+    .catch(error => {
+        console.error('Error in sending request:', error);
+        sendResponse({ status: 500 });
+    });
 
     return true;
 });
 
-chrome.browserAction.onClicked.addListener(function (tab) {
+chrome.action.onClicked.addListener(function (tab) {
     chrome.tabs.create({
-        'url': chrome.extension.getURL('options.html')
+        'url': chrome.runtime.getURL('options.html')
     });
 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -4,14 +4,10 @@ console.log('content.js loaded');
 window.postMessage({
     ZebraPrintingExtensionId: chrome.runtime.id,
     ZebraPrintingVersion: chrome.runtime.getManifest().version
-}, "*");
+}, '*');
 
 // Listen to messages from the current website
-window.addEventListener("message", function (event) {
-    if (typeof event.data.type === 'undefined') {
-        return;
-    }
-
+window.addEventListener('message', function (event) {
     if (event.data.type != 'zebra_print_label') {
         return;
     }
@@ -19,6 +15,6 @@ window.addEventListener("message", function (event) {
     console.log('Forwarding message to background.js');
 
     chrome.runtime.sendMessage(event.data, function (response) {
-        console.log(response);
+        console.log(response); // {status: 200}
     });
-}, false);
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,33 +1,32 @@
 {
-    "manifest_version": 2,
-    "name": "Zebra Printing",
-    "version": "1.2",
-    "description": "Allows to print ZPL to a network connected Zebra printer.",
-    "icons": {
-        "128": "zebra128.png"
-    },
-    "author": "Daniel Nitz",
-    "permissions": [
-        "<all_urls>",
-        "background",
-        "activeTab"
-    ],
-    "content_scripts": [
-        {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": [
-                "content.js"
-            ]
-        }
-    ],
-    "background": {
-        "scripts": [
-            "background.js"
-        ],
-        "persistent": false
-    },
-    "browser_action": {},
-    "offline_enabled": true
+  "manifest_version": 3,
+  "name": "Zebra Printing",
+  "version": "1.2",
+  "description": "Allows to print ZPL to a network connected Zebra printer.",
+  "icons": {
+    "128": "zebra128.png"
+  },
+  "author": "Daniel Nitz",
+  "permissions": [
+    "activeTab",
+    "scripting"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ]
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {},
+  "offline_enabled": true
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zebra Printing",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Allows to print ZPL to a network connected Zebra printer.",
   "icons": {
     "128": "zebra128.png"

--- a/extension/options.html
+++ b/extension/options.html
@@ -11,7 +11,6 @@
 </head>
 
 <body>
-
     <div class="mdl-layout mdl-js-layout">
 
         <div class="ribbon"></div>
@@ -37,9 +36,9 @@
 
                         <div class="mdl-grid">
                             <div class="mdl-cell  mdl-cell--12-col">
-                                <div class="mdl-textfield mdl-js-textfield">
+                                <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
                                     <textarea class="mdl-textfield__input" type="text" rows="3" id="zpl"></textarea>
-                                    <label class="mdl-textfield__label" for="zpl">ZPL here...</label>
+                                    <label class="mdl-textfield__label" for="zpl">ZPL Code</label>
                                 </div>
                             </div>
                         </div>
@@ -55,11 +54,10 @@
                     </form>
 
                     <div class="mdl-grid">
-
                         <div class="mdl-cell mdl-cell--12-col">
                             <h6>Simple ZPL Test Print</h6>
                             <p>Just copy & paste this:</p>
-                            <p>^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ</p>
+                            <code>^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ</code>
                         </div>
                     </div>
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -2,10 +2,10 @@ var print = document.getElementById('print');
 
 print.onclick = function () {
     console.log('Print button clicked.');
-    chrome.extension.sendMessage({
-        type: "zebra_print_label",
+    chrome.runtime.sendMessage({
+        type: 'zebra_print_label',
         zpl: document.getElementById('zpl').value,
-        url: "http://" + document.getElementById('printerAddress').value + "/pstprnt"
+        url: 'http://' + document.getElementById('printerAddress').value + '/pstprnt'
     });
     return false;
 }

--- a/testing/index.html
+++ b/testing/index.html
@@ -6,23 +6,24 @@
 </body>
 
 <script>
-    (function () {
-        window.addEventListener("message", function (event) {
-            if (!event.data.ZebraPrintingVersion) {
-                return;
-            }
-            console.log(event.data);
-        });
+(function () {
+    window.addEventListener('message', function (event) {
+        if (!event.data.ZebraPrintingVersion) {
+            return;
+        }
+        console.log(event.data); // {ZebraPrintingExtensionId: 'ikcjnjdjpfkhhoionghihboodimhipla', ZebraPrintingVersion: '1.2'}
+    });
 
-        document.getElementById("btn").addEventListener("click", function () {
-            console.log('Sending print message from the web page...');
-            window.postMessage({
-                type: "zebra_print_label",
-                zpl: "^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ",
-                url: "http://192.168.38.10/pstprnt"
-            }, "*");
-        }, false);
-    })();
+    document.getElementById('btn').addEventListener('click', function () {
+        console.log('Sending print message from the web page...');
+
+        window.postMessage({
+            type: 'zebra_print_label',
+            zpl: '^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ',
+            url: 'http://localhost:8080/pstprnt'
+        }, '*');
+    }, false);
+})();
 </script>
 
 </html>

--- a/testing/simple-test.js
+++ b/testing/simple-test.js
@@ -2,6 +2,19 @@
  * Working example. Copy & paste it into your Chrome Console and a test label
  * will be printed.
  */
-var request = new XMLHttpRequest();
-request.open('POST', 'http://52j173100627.intern/pstprnt', true);
-request.send('^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ');
+fetch('http://localhost:8080/pstprnt', {
+    method: 'POST',
+    body: '^XA^PW400^LL200^FO20,20^A0N,30,30^FDThis is a TEST^FS^XZ'
+})
+.then(response => {
+    if (!response.ok) {
+        throw new Error('Network response was not ok');
+    }
+    return response.status;
+})
+.then(data => {
+    console.log('Response from server:', data);
+})
+.catch(error => {
+    console.error('Error in sending request:', error);
+});


### PR DESCRIPTION
Manifest V2 support timeline
https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline


**@danielnitz Please accept this pull request and update the extension in the Chrome Web Store. It's fully tested _(with custom golang server, with real network printer from testing/index.html, with real web application printing to network printer)_ but if you want to test it, you can clone my repo locally and test it before merging.**


## Changes made with this pull request

!! There are no breaking changes, API is still same. It will work with all present applications.

### Manifest v2 -> Manifest v3
* manifest.json file updated to Manifest v3.
* manifest.json version bumped to **1.3**
* All js codes updated to Manifest v3.
	* _XMLHttpRequest()_ -> _fetch()_
	* _chrome.browserAction.onClicked.addListener()_ -> _chrome.action.onClicked.addListener()_
	* _chrome.extension.getURL()_ -> _chrome.runtime.getURL()_
	* content.js, _window.addEventListener()_
		* We don't need to check if "_event.data.type_" is "_undefined_", it will never be.
		* We don't need second parameter which is "_false_".

### README file
- Chrome extension logo fixed.
- Code blocks fixed for syntax highlighting.
- ZD620, ZD621, GK420d added to the tested printers.

## Note

The original test server serves only static index file, and it prints to a real printer or another simulated printer. I tried to rebuild the testing with two endpoints: one to serve the static files and the other to receive POST requests and print to the shell/console.

After dozens of tries, I could not make it work with the Python standard library. It was not printing the received POST request unless I refreshed the browser, and after a few refreshes, it became hard to exit the Python server with CTRL+C. It's taking very long for Python to catch CTRL+C. I don't think it's an extension issue because my Golang server works just fine.

**So, there are no changes for the testing/ directory.**

### My testing server


![image](https://github.com/user-attachments/assets/5f0b28eb-bfb8-4410-b313-72641e155fdf)

http-server.go
```go
package main

import (
    "fmt"
    "io"
    "log"
    "time"
    "net/http"
)

func main() {
    fs := http.FileServer(http.Dir(".")) // Serve static files from current directory
    http.Handle("/", fs)                 // Root path handler

    // Emulated printer webprint endpoint
    http.HandleFunc("/pstprnt", func(w http.ResponseWriter, r *http.Request) {
        if r.Method!= http.MethodPost {
            http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)

            return
        }

        body, err := io.ReadAll(r.Body)
        if err!= nil {
            http.Error(w, "Error reading request body", http.StatusInternalServerError)

            return
        }

        dt := time.Now().Format("02.01.2006 15:04:05") // Day.Month.Year
        fmt.Printf("[%s] POST request received: %s\n", dt, string(body))

        w.WriteHeader(http.StatusOK)
        w.Write([]byte("Post request handled."))
    })

    serverAddress := "localhost:8080"
    fmt.Printf("🐹 http server started on %s\n", serverAddress)
	log.Fatal(http.ListenAndServe(serverAddress, nil))
}
```
