### PR TITLE
Add extension ping mechanism to improve message reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The event will contain two fields:
 - ZebraPrintingExtensionId: The extension ID (ndikjdigobmbieacjcgomahigeiobhbo)
 - ZebraPrintingVersion: The version number of the installed extension
 
+Optionally, you can send a message with the type `zebra_ping`, and the extension will respond with the same message. This can be useful if your code adds the event listener after the initial message has already been sent.
+
+
 ## Tested Printers
 
 - ZT220 with firmware V72.19.15Z, V72.20.01Z

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,18 +1,29 @@
 // Notify current website about the existence of this chrome extension
-window.postMessage({
-    ZebraPrintingExtensionId: chrome.runtime.id,
-    ZebraPrintingVersion: chrome.runtime.getManifest().version
-}, '*');
+function notifyExtension() {
+    window.postMessage(
+        {
+            ZebraPrintingExtensionId: chrome.runtime.id,
+            ZebraPrintingVersion: chrome.runtime.getManifest().version,
+        },
+        "*"
+    );
+}
+
+notifyExtension();
 
 // Listen to messages from the current website
-window.addEventListener('message', function (event) {
-    if (typeof event.data.type === 'undefined') {
+window.addEventListener("message", function (event) {
+    if (typeof event.data.type === "undefined") {
         return;
     }
 
-    if (event.data.type != 'zebra_print_label') {
+    if (event.data.type == "zebra_print_label") {
+        chrome.runtime.sendMessage(event.data);
         return;
     }
 
-    chrome.runtime.sendMessage(event.data);
+    if (event.data.type == "zebra_ping") {
+        notifyExtension();
+        return;
+    }
 });

--- a/extension/content.js
+++ b/extension/content.js
@@ -5,24 +5,24 @@ function notifyExtension() {
             ZebraPrintingExtensionId: chrome.runtime.id,
             ZebraPrintingVersion: chrome.runtime.getManifest().version,
         },
-        "*"
+        '*'
     );
 }
 
 notifyExtension();
 
 // Listen to messages from the current website
-window.addEventListener("message", function (event) {
-    if (typeof event.data.type === "undefined") {
+window.addEventListener('message', function (event) {
+    if (typeof event.data.type === 'undefined') {
         return;
     }
 
-    if (event.data.type == "zebra_print_label") {
+    if (event.data.type == 'zebra_print_label') {
         chrome.runtime.sendMessage(event.data);
         return;
     }
 
-    if (event.data.type == "zebra_ping") {
+    if (event.data.type == 'zebra_ping') {
         notifyExtension();
         return;
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zebra Printing",
-  "version": "1.6",
+  "version": "1.7",
   "description": "Allows to print ZPL to a network connected Zebra printer.",
   "icons": {
     "128": "zebra128.png"


### PR DESCRIPTION
## Context

I was experiencing issues where the message sent by the extension was not being received by my React app. The problem occurred because the event listener was not being registered in time.

## Changes

* Added support for the extension to respond to a "ping" message, allowing the React app to verify the connection and ensure readiness before other messages are exchanged.

## Notes

Please let me know if you encounter any issues with the implementation or have suggestions for improvement.
@danielnitz 
